### PR TITLE
Dualport Imem Added

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ else
 ifeq ($(Target), hydrogensoc)
 verilog_topmodule = HydrogenSoC
 verilog_topmodule_file = $(rtl_dir)/$(verilog_topmodule).v
-verilog_files = $(verilog_topmodule_file) $(rtl_dir)/Timescale.vh $(rtl_dir)/Config.vh $(rtl_dir)/uncore/BiDirectionalIO.v $(rtl_dir)/uncore/GPIO.v $(rtl_dir)/uncore/SinglePortROM_wb.v $(rtl_dir)/uncore/SinglePortRAM_wb.v $(rtl_dir)/uncore/simpleuart_wb.v $(rtl_dir)/uncore/simpleuart.v $(rtl_dir)/core/AtomRV_wb.v $(rtl_dir)/core/AtomRV.v $(rtl_dir)/core/Alu.v $(rtl_dir)/core/Decode.v $(rtl_dir)/core/RegisterFile.v
+verilog_files = $(verilog_topmodule_file) $(rtl_dir)/Timescale.vh $(rtl_dir)/Config.vh $(rtl_dir)/uncore/BiDirectionalIO.v $(rtl_dir)/uncore/GPIO.v $(rtl_dir)/uncore/DualPortRAM_wb.v $(rtl_dir)/uncore/SinglePortRAM_wb.v $(rtl_dir)/uncore/simpleuart_wb.v $(rtl_dir)/uncore/simpleuart.v $(rtl_dir)/core/AtomRV_wb.v $(rtl_dir)/core/AtomRV.v $(rtl_dir)/core/Alu.v $(rtl_dir)/core/Decode.v $(rtl_dir)/core/RegisterFile.v
 VFLAGS += -D__IMEM_INIT_FILE__='"$(RVATOM)/$(init_dir)/code.hex"'
 VFLAGS += -D__DMEM_INIT_FILE__='"$(RVATOM)/$(init_dir)/data.hex"'
 

--- a/rtl/uncore/DualPortRAM_wb.v
+++ b/rtl/uncore/DualPortRAM_wb.v
@@ -1,0 +1,87 @@
+`default_nettype none
+
+module DualPortRAM_wb #(
+    // Parameters
+    parameter ADDR_WIDTH = 16,
+    parameter MEM_FILE = ""
+)
+(
+    // Global Signals
+    input   wire                    wb_clk_i,
+    input   wire 		            wb_rst_i,
+    
+    // Wishbone Interface (Read & Write)
+    input   wire  [ADDR_WIDTH-1:2]  wb_adr_i,
+    output  reg   [31:0] 	        wb_dat_o,
+    input   wire  [31:0] 	        wb_dat_i,
+    input   wire 		            wb_we_i,
+    input   wire  [3:0] 	        wb_sel_i,
+    
+    input   wire                    wb_stb_i,
+    output  reg 		            wb_ack_o,
+
+    // Wishbone Interface (Read Only)
+    input   wire  [ADDR_WIDTH-1:2]  wb_roport_adr_i,
+    output  reg   [31:0] 	        wb_roport_dat_o,
+    
+    input   wire                    wb_roport_stb_i,
+    output  reg		                wb_roport_ack_o
+
+);
+
+// Calculate depth from address width
+localparam DEPTH = 1 << ADDR_WIDTH;
+
+reg [31:0] 		mem [0:DEPTH/4-1] /* verilator public */;
+
+// Initialize the contents of memory from an hex file
+initial begin
+  if(|MEM_FILE) begin
+    $readmemh(MEM_FILE, mem);
+  end
+end
+
+wire [3:0] 		        we    = {4{wb_we_i & wb_stb_i}} & wb_sel_i;
+wire [ADDR_WIDTH-3:0] addr  = wb_adr_i[ADDR_WIDTH-1:2];
+
+// Set Ack_o
+always @(posedge wb_clk_i) begin
+  if (wb_rst_i)
+    wb_ack_o <= 1'b0;
+  else
+    wb_ack_o <= wb_stb_i & !wb_ack_o;
+end
+
+// Handle Reads & Writes
+always @(posedge wb_clk_i) begin
+  if (we[0]) mem[addr][7:0]   <= wb_dat_i[7:0];
+  if (we[1]) mem[addr][15:8]  <= wb_dat_i[15:8];
+  if (we[2]) mem[addr][23:16] <= wb_dat_i[23:16];
+  if (we[3]) mem[addr][31:24] <= wb_dat_i[31:24];
+  
+  wb_dat_o <= mem[addr];
+end
+
+//////////////////////////////////////////////////////
+// Read Only (RO) Port Logic
+
+wire [ADDR_WIDTH-3:0] roport_addr  = wb_roport_adr_i[ADDR_WIDTH-1:2];
+
+// Set Ack_o
+always @(posedge wb_clk_i) begin
+  if(wb_rst_i)
+    wb_roport_ack_o <= 0;
+  else
+    wb_roport_ack_o <= wb_roport_stb_i && !wb_roport_ack_o;
+end
+
+
+// Handle Reads
+always @(posedge wb_clk_i) begin
+  if(wb_rst_i)
+    wb_roport_dat_o <= 0;
+  else
+    wb_roport_dat_o <= mem[roport_addr];
+end
+
+endmodule

--- a/sim/Backend_HydrogenSoC.hpp
+++ b/sim/Backend_HydrogenSoC.hpp
@@ -11,7 +11,7 @@
 #include "../build/vobj_dir/VHydrogenSoC_AtomRV.h"
 #include "../build/vobj_dir/VHydrogenSoC_RegisterFile__R20_RB5.h"
 
-#include "../build/vobj_dir/VHydrogenSoC_SinglePortROM_wb__pi1.h"
+#include "../build/vobj_dir/VHydrogenSoC_DualPortRAM_wb__pi1.h"
 #include "../build/vobj_dir/VHydrogenSoC_SinglePortRAM_wb__pi2.h"
 #include "../build/vobj_dir/VHydrogenSoC_simpleuart_wb.h"
 

--- a/sw/lib/libcatom/lcd.c
+++ b/sw/lib/libcatom/lcd.c
@@ -154,14 +154,14 @@ void lcd_write(int isData, char byte)
     sleep(1);
 
     // Pull all pins LOW
-    gpio_write(lcd_pin_rs, GPIO_LOW);
-    gpio_write(lcd_pin_rw, GPIO_LOW);
-    gpio_write(lcd_pin_en, GPIO_LOW);
+    gpio_write(lcd_pin_rs, LOW);
+    gpio_write(lcd_pin_rw, LOW);
+    gpio_write(lcd_pin_en, LOW);
 
-    gpio_write(lcd_pin_d4, GPIO_LOW);
-    gpio_write(lcd_pin_d5, GPIO_LOW);
-    gpio_write(lcd_pin_d6, GPIO_LOW);
-    gpio_write(lcd_pin_d7, GPIO_LOW);
+    gpio_write(lcd_pin_d4, LOW);
+    gpio_write(lcd_pin_d5, LOW);
+    gpio_write(lcd_pin_d6, LOW);
+    gpio_write(lcd_pin_d7, LOW);
 }
 
 


### PR DESCRIPTION
Dual-port IMEM now enables read-write access to Instruction memory via the data bus.
Port 1 of the dual-port memory is a read-only port that is used to fetch instructions, while the other port is a read-write port - accessed through the data bus.